### PR TITLE
Turned single-day weather into a five-day forecast

### DIFF
--- a/scripts/weather/WeatherData.js
+++ b/scripts/weather/WeatherData.js
@@ -1,4 +1,4 @@
-export const weatherDataHTML = (weatherObject) => {
+  export const weatherDataHTML = (weatherObject) => {
     const kToF = (tempInKelvin) => {
         return `${Math.floor((tempInKelvin-273) * (9/5) +32)}`
     }

--- a/scripts/weather/WeatherData.js
+++ b/scripts/weather/WeatherData.js
@@ -1,32 +1,44 @@
-  export const weatherDataHTML = (weatherObject) => {
-    const kToF = (tempInKelvin) => {
-        return `${Math.floor((tempInKelvin-273) * (9/5) +32)}`
-    }
-    
-    const todaysDate = new Date().toDateString()
-    const timeNow = new Date().toLocaleTimeString()
+import { useWeather } from "./WeatherDataProvider.js"
 
-    const currentTemp = kToF(weatherObject.list[0].main.temp)
-    const feelsLike = kToF(weatherObject.list[0].main.feels_like)
-    const highTemp = kToF(weatherObject.list[0].main.temp_max)
-    const lowTemp = kToF(weatherObject.list[0].main.temp_min)
-    
-    return `
-    <div class="weather">
-        <div class="current">${todaysDate} ${timeNow}
-            <div class="conditions">
-                <div class="conditions__current">Current Conditions: ${weatherObject.list[0].weather[0].description}</div>
+  export const weatherDataHTML = () => {
+    //get all the weather data in 3hr increments and store in an array
+    const allWeatherData = useWeather()
+    const threeHourData = allWeatherData.list
+
+    //store just the times that we need in a new, smaller array
+    let fiveDayForecast = [threeHourData[0],threeHourData[8],threeHourData[16],
+        threeHourData[24],threeHourData[32]]
+
+    //this is a function that turns the dates from unix into a more pleasant date
+    const dateTransform = (specificDayDate) => {
+        const unix = specificDayDate
+        const milli = unix * 1000
+        const dateTime = new Date(milli)
+        const Month = dateTime.toLocaleString('default', { month: 'long' })
+        const Day = dateTime.getDate()
+        const Year = dateTime.getFullYear()
+        return `${Month} ${Day}, ${Year}`
+      }
+
+
+    //map through all of the times and create HTML representation for each
+    const forecastHTML = fiveDayForecast.map((specificDay) => {
+        return `
+            <div class="forecast__day">
+                <div class="date">${dateTransform(specificDay.dt)}</div>
+                <div class="temperatures">
+                    <div class="temp">Current Temperature: ${Math.floor(specificDay.main.temp)}\xB0F</div>
+                    <div class="feelsLike">Feels Like: ${Math.floor(specificDay.main.feels_like)}\xB0F</div>
+                    <div class="high">High: ${Math.floor(specificDay.main.temp_max)}\xB0F</div>
+                    <div class="low">Low: ${Math.floor(specificDay.main.temp_min)}\xB0F</div>
+                </div>
+                <div class="conditions">Forcast: ${specificDay.weather[0].description}</div>
+                <div class="humidity">Humidity: ${specificDay.main.humidity}</div>
+                <div class="wind">Wind Speed: ${Math.floor(specificDay.wind.speed)}mph</div>
             </div>
-            <div class="temperature"
-                <div class="temp__currentTemp">Current Temp: ${currentTemp}</div>
-                <div class="temp__feelsLike">Feels Like: ${feelsLike}</div>
-                <div class="temp__tempHigh">High: ${highTemp}</div>
-                <div class="temp__tempLow">Low: ${lowTemp}</div>
-            </div>
-            <div class="windSpeed">
-                <div class="windSpeedCurrent">Wind Speed: ${weatherObject.list[0].wind.speed}mph</div>
-            </div>
-        </div>
-    </div>
-    `
-}
+        `
+    }).join("")
+
+    //return the HTML representation for the full forecast
+    return forecastHTML
+  }

--- a/scripts/weather/WeatherDataProvider.js
+++ b/scripts/weather/WeatherDataProvider.js
@@ -13,7 +13,7 @@ export const useWeather = () => {
 
 // fetching parks from API
 export const getWeather = (latitude, longitude) => {
-    return fetch(`http://api.openweathermap.org/data/2.5/forecast?lat=${latitude}&lon=${longitude}&APPID=${apiKeys.weatherKey}`)
+    return fetch(`http://api.openweathermap.org/data/2.5/forecast?units=imperial&lat=${latitude}&lon=${longitude}&APPID=${apiKeys.weatherKey}`)
     //taking what was recieved(promise) and turning it into java
         .then(response => response.json())
         //taking that java and storing it then putting it in parks

--- a/scripts/weather/WeatherDisplay.js
+++ b/scripts/weather/WeatherDisplay.js
@@ -33,10 +33,11 @@ eventHub.addEventListener("parkChosen", event =>{
     
     //get the weather data for the park with the specific lat and long
     getWeather(latitudeOfSelectedPark, longitudeOfSelectedPark).then(() => {
-        //then store the returned weather data in a variable
-        const weatherData = useWeather()
-        //then pass the weather data into the function that turns object into HTML
-        //and update contentTarget with HTML representation of weather data
-        contentTarget.innerHTML = weatherDataHTML(weatherData)
+        //update contentTarget with HTML representation of weather data
+        contentTarget.innerHTML = `
+        <div class="forecast">
+        ${weatherDataHTML()}
+        </div>
+        `
     })
 })

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,3 +1,5 @@
+@import 'weather.css';
+
 * {
     box-sizing: border-box;
 }

--- a/styles/weather.css
+++ b/styles/weather.css
@@ -1,0 +1,13 @@
+.forecast {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.forecast__day {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.date, .temperatures, .conditions, .humidity, .wind {
+    flex-basis: 100%;
+}


### PR DESCRIPTION
##Changes
-displayed a five-day forecast rather than a single day weather display
-created weather.css and imported into main.css
-edited fetch call to fetch degF temperatures rather than kelvin

##To Test
-run serve db.JSON
-select a park from the dropdown and ensure a five day forecast for that location displays
-suggest any changes/additional information for the forecast
-try with other features in the previewContainer
-try several different parks